### PR TITLE
Narrows vault token regex

### DIFF
--- a/yara-rules/access_tokens/hashicorp_vault_access_token.yar
+++ b/yara-rules/access_tokens/hashicorp_vault_access_token.yar
@@ -9,7 +9,7 @@ rule HashicorpVaultAccessTokenRule
         test_match_1 = "s.OZZFOsivUeOMeDyFtRz7cOmE"
 
     strings:
-        $ = /s.[0-9A-Za-z]{24}/ fullword
+        $ = /\bs.[0-9A-Za-z]{24}\b/ fullword
 
     condition:
         any of them


### PR DESCRIPTION
I really can't remember the purpose of this branch. Was it a bug?

Either merge it or close it :smile: 